### PR TITLE
Fix build failure with a recent glibc due to struct FILE being redefined

### DIFF
--- a/src/libc/stdio_remap.h
+++ b/src/libc/stdio_remap.h
@@ -16,6 +16,8 @@
 
 // musl libc needs to to not try to define FILE in headers
 #define __DEFINED_FILE
+// the same goes with the macro below for recent glibc versions
+#define __FILE_defined 1
 
 #define asprintf	bk_asprintf
 //#define clearerr	bk_clearerr


### PR DESCRIPTION
Recent glibc versions (at least version 2.27) need __FILE_defined macro to
be set to 1, otherwise the build will fail.

This is because libc/unix.h includes pwd.h, which then includes
bits/types/FILE.h, which will define struct FILE type unless the
aforementioned macro is set.
